### PR TITLE
Feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/*
 dist/*
 .DS_Store
 pybyte.egg-info/
+
+.idea/

--- a/pybyte/__init__.py
+++ b/pybyte/__init__.py
@@ -2,3 +2,4 @@ from pybyte.byte import Byte
 from pybyte.post import BytePost
 from pybyte.user import ByteAccount, ByteUser
 from pybyte.endpoints import Endpoints
+from pybyte.feed import ByteFeed

--- a/pybyte/byte.py
+++ b/pybyte/byte.py
@@ -8,7 +8,6 @@ from pybyte.session import ByteSession
 from pybyte.user import ByteAccount, ByteUser
 from pybyte.post import BytePost
 
-from ffprobe import FFProbe
 from ffmpy import FFmpeg
 
 
@@ -84,6 +83,8 @@ class Byte(object):
 
 
     def upload(self, file_path, caption=""):
+
+        """
         try:
             metadata = FFProbe(file_path)
             metadata_information = metadata.streams[0]
@@ -92,6 +93,7 @@ class Byte(object):
 
         except Exception as error:
             raise Exception(f"FFProbe failed: {error}")
+        """
 
         try:
             logger.info("generating a thumbnail")

--- a/pybyte/endpoints.py
+++ b/pybyte/endpoints.py
@@ -26,3 +26,6 @@ class Endpoints:
     FOLLOW = return_follow
     UPLOAD = base + "/upload"
     POST = base + "/post"
+    POPULAR = base + "/feed/popular/v2"
+    GLOBAL = base + '/feed/global'
+    TIMELINE = base + "/timeline"

--- a/pybyte/feed.py
+++ b/pybyte/feed.py
@@ -1,0 +1,44 @@
+from loguru import logger
+
+class ByteFeed(object):
+    def __init__(self, feed_url, feed_data, byteSession_provided, feedArrayReturnObject, feedArrayKey="posts"):
+        self._entireFeed = feed_data
+        self._providedData = self._entireFeed['data']
+        self._internalSession = byteSession_provided
+        self._feedArrayKey = feedArrayKey
+        self._feedArrayReturnObject = feedArrayReturnObject
+        self._feedURL = feed_url
+
+    def __nextCursor(self, cursor):
+        try:
+            update_cursor = {
+                "cursor": cursor
+            }
+            attempt_get = self._internalSession.get(
+                self._feedURL, params=update_cursor
+            )
+            if attempt_get.status_code == 200:
+                self.__init__(self._feedURL, attempt_get.json(), self._internalSession,
+                              self._feedArrayReturnObject, feedArrayKey=self._feedArrayKey)
+                return True
+            else:
+                raise Exception(f"Byte API failed to get next cursor. {attempt_get.status_code}")
+        except Exception as error:
+            logger.error(f"unable to complete block. {error}")
+            raise Exception("Unable to complete next cursor.")
+
+    @property
+    def feed(self):
+        currentEndOfList = self._providedData[self._feedArrayKey][-1]
+        endOfFeed = False
+        while endOfFeed == False:
+            for item in self._providedData[self._feedArrayKey]:
+                if item['id'] == currentEndOfList['id']:
+                    try:
+                        self.__nextCursor(self._entireFeed['data']['cursor'])
+                    except Exception as error:
+                        logger.error(f"error on going to next cursor: {error}")
+                        endOfFeed = True
+                else:
+                    yield self._feedArrayReturnObject(item['id'], self._internalSession)
+

--- a/pybyte/post.py
+++ b/pybyte/post.py
@@ -6,8 +6,8 @@ from loguru import logger
 from pybyte.endpoints import Endpoints
 import arrow
 import pathlib
-from pybyte.user import ByteUser
 from pybyte.session import ByteSession
+from pybyte.feed import ByteFeed
 
 def convert_dict(dict):
     return json.dumps(dict)
@@ -70,7 +70,8 @@ class BytePost(object):
 
     @property
     def author(self):
-        return ByteUser(self._post_info['id'], self._session)
+        from pybyte.user import ByteUser
+        return ByteUser(self._post_info['authorID'], self._session)
 
     @property
     def caption(self):
@@ -94,12 +95,14 @@ class BytePost(object):
 
     @property
     def mentions(self):
+        from pybyte.user import ByteUser
         if self._post_info.get('mentions', False) != False:
             return [ByteUser(user['accountID'], self._session) for user in self._post_info['mentions']]
         else:
             return []
 
     def likes(self):
+        from pybyte.user import ByteUser
         try:
             req_send = self._session.get(
                 Endpoints.LIKE(self._post_id), data=convert_dict({'postID': self._post_id})
@@ -117,6 +120,7 @@ class BytePost(object):
 
 
     def rebyte(self):
+        
         try:
             req_send = self._session.post(
                 Endpoints.REBYTE, data=convert_dict({'postID': self._post_id})
@@ -192,3 +196,4 @@ class BytePost(object):
         except Exception as error:
             logger.error(f'rebyte error: {error}')
             return False
+


### PR DESCRIPTION
Support for viewing Byte API feeds.

These feeds are usually organized in this matter

```json
{
	"data": {
		"posts": [/*array of posts */],
		"cursor": "cursorValue",
	"accounts": [/*array of accounts */]
	}
}
```

Cursors are used to view the next page of results.
``ByteFeed`` will return a **generator** of appr objects and will automatically paginate the next set of results.

ByteFeed takes in the entire response, and you must provide the arrayKey as well as the object each item will return as.

For example, if you want to interact with a set of posts
ByteFeed will need the data as well as ``"posts"`` and ``BytePost``

Another example, if you want to interact with a set accounts for a post
ByteFeed will need the data as well as ``accounts`` and ``ByteUser``.

It will return a generator. Access this by using the ``.feed`` attribute of the returned ``ByteFeed``.


Most of the time you aren't going to be passing in these values, pybyte will do it for you.